### PR TITLE
ServiceNow

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use clipboard::{ClipboardContext, ClipboardProvider};
 use colored::*;
+use scrapers::servicenow::scraper::scrape_servicenow;
 use core::panic;
 use cron::initialize_cron;
 use dialoguer::theme::ColorfulTheme;
@@ -64,7 +65,7 @@ use webbrowser;
 
 // TODO: Keys should prob be lowercase, make a tuple where 0 is key and 1 is display name, or
 // straight up just an enum
-const COMPANYKEYS: [&str; 24] = [
+const COMPANYKEYS: [&str; 25] = [
     "AirBnB",
     "Anduril",
     "Blizzard",
@@ -86,6 +87,7 @@ const COMPANYKEYS: [&str; 24] = [
     "Netflix",
     "Meta",
     "Chase",
+    "ServiceNow",
     "Square",
     "Stripe",
     "Salesforce",
@@ -593,7 +595,7 @@ pub async fn scrape_jobs(
         "Square" => scrape_square(data).await,
         "Stripe" => scrape_stripe(data).await,
         "Salesforce" => scrape_salesforce(data).await,
-
+        "ServiceNow" => scrape_servicenow(data).await,
         "GitHub" => default_scrape_jobs_handler(data, GITHUB_SCRAPE_OPTIONS).await,
         "GitLab" => default_scrape_jobs_handler(data, GITLAB_SCRAPE_OPTIONS).await,
         "The Browser Company" => {

--- a/src/scrapers/mod.rs
+++ b/src/scrapers/mod.rs
@@ -47,3 +47,6 @@ pub mod stripe {
 pub mod airbnb {
 	pub mod scraper;
 }
+pub mod servicenow {
+	pub mod scraper;
+}

--- a/src/scrapers/servicenow/scraper.rs
+++ b/src/scrapers/servicenow/scraper.rs
@@ -1,0 +1,77 @@
+use std::error::Error;
+
+use headless_chrome::{Browser, LaunchOptions};
+
+use crate::models::{
+    data::Data,
+    scraper::{JobsPayload, ScrapedJob},
+};
+
+pub async fn scrape_servicenow(data: &mut Data) -> Result<JobsPayload, Box<dyn Error>> {
+    let launch_options = LaunchOptions {
+        headless: false,
+        window_size: Some((1920, 1080)),
+        enable_logging: true,
+
+        ..LaunchOptions::default()
+    };
+    let browser = Browser::new(launch_options)?;
+
+    let tab = browser.new_tab()?;
+    tab.wait_for_element("body")?;
+    let mut page = 1;
+    let mut scraped_jobs: Vec<ScrapedJob> = Vec::new();
+
+    loop {
+        let url = format!("https://careers.servicenow.com/jobs/?page={page}&team=Engineering,%20Infrastructure%20and%20Operations&pagesize=50#results");
+        tab.navigate_to(&url)?;
+        tab.wait_for_element("#js-job-search-results")?;
+
+        let remote_object = tab.evaluate(
+            r##"
+
+const jobCards = [...document.querySelectorAll(".card.card-job")].map(node => {
+    const title = node.querySelector(".card-title").textContent.trim();
+
+    // Clean and join locations
+    const location = node.querySelector(".list-inline-item").textContent.trim()
+
+    const link = node.querySelector("a").href.trim();
+    
+    return {
+        title,
+        location,
+        link
+    };
+});
+
+JSON.stringify(jobCards);
+    "##,
+            false,
+        )?;
+
+        let results = remote_object.value.as_ref().unwrap();
+
+        // TODO: Fix this eventually
+        if results.as_str().unwrap() == "[]" {
+            break;
+        }
+
+        let scraped_jobs_subset: Vec<ScrapedJob> = serde_json::from_str(results.as_str().unwrap())?;
+
+        scraped_jobs.extend(scraped_jobs_subset);
+
+        page += 1;
+    }
+
+    // Convert Vector of ScrapedJob into a JobsPayload
+    let jobs_payload = JobsPayload::from_scraped_jobs(scraped_jobs, &data.data["ServiceNow"]);
+
+    // REMEBER TO SAVE THE NEW JOBS TO THE DATA STATE
+    data.data.get_mut("ServiceNow").unwrap().jobs = jobs_payload.all_jobs.clone();
+    data.save();
+
+    // Return JobsPayload
+    Ok(jobs_payload)
+}
+


### PR DESCRIPTION
This pull request introduces functionality to scrape job listings from ServiceNow and integrates it into the existing job scraping system. The most important changes include adding a new scraper module for ServiceNow, updating constants and functions to include ServiceNow, and implementing the scraping logic.

Integration of ServiceNow job scraping:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR4): Added `scrape_servicenow` to the imports and updated `COMPANYKEYS` to include "ServiceNow". Updated the `scrape_jobs` function to handle ServiceNow jobs. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR4) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL67-R68) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR90) [[4]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL596-R598)

Addition of ServiceNow scraper module:

* [`src/scrapers/mod.rs`](diffhunk://#diff-1afca3ad4e63fab9249218cc2f68982c09c0e6c0fad68c0e440797f9733a9bf5R50-R52): Added a new module `servicenow` with a submodule `scraper`.
* [`src/scrapers/servicenow/scraper.rs`](diffhunk://#diff-653566cc0796b3a4168d18f9b97a44ed30b6afb6bf79bb6e825483743f203718R1-R77): Implemented the `scrape_servicenow` function, which uses headless Chrome to scrape job listings from the ServiceNow careers page.