### PR TITLE
company: Cloudflare

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use clipboard::{ClipboardContext, ClipboardProvider};
 use colored::*;
+use scrapers::cloudflare::scraper::scrape_cloudflare;
 use scrapers::servicenow::scraper::scrape_servicenow;
 use core::panic;
 use cron::initialize_cron;
@@ -65,11 +66,12 @@ use webbrowser;
 
 // TODO: Keys should prob be lowercase, make a tuple where 0 is key and 1 is display name, or
 // straight up just an enum
-const COMPANYKEYS: [&str; 25] = [
+const COMPANYKEYS: [&str; 26] = [
     "AirBnB",
     "Anduril",
     "Blizzard",
     "Cisco",
+    "Cloudflare",
     "CoStar Group",
     "Experian",
     "1Password",
@@ -577,6 +579,7 @@ pub async fn scrape_jobs(
         "AirBnB" => scrape_airbnb(data).await,
         "Anduril" => default_scrape_jobs_handler(data, ANDURIL_SCRAPE_OPTIONS).await,
         "Chase" => scrape_chase(data).await,
+        "Cloudflare" => scrape_cloudflare(data).await,
         "Cisco" => scrape_cisco(data).await,
         "CoStar Group" => scrape_costar_group(data).await,
         "Blizzard" => scrape_blizzard(data).await,

--- a/src/scrapers/cloudflare/scraper.rs
+++ b/src/scrapers/cloudflare/scraper.rs
@@ -1,0 +1,65 @@
+use std::error::Error;
+
+use reqwest::Client;
+use serde_json::Value;
+
+use crate::models::{
+    data::Data,
+    scraper::{JobsPayload, ScrapedJob},
+};
+
+pub async fn scrape_cloudflare(data: &mut Data) -> Result<JobsPayload, Box<dyn Error>> {
+    let mut scraped_jobs: Vec<ScrapedJob> = Vec::new();
+
+    let mut json: Value = Client::new()
+        .get("https://boards-api.greenhouse.io/v1/boards/cloudflare/departments/?render_as=tree")
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    let departments = json["departments"].as_array_mut().unwrap();
+
+    let engineering_dep_id = 29067;
+    let emerging_technologies_dep_id = 39629;
+    departments.retain(|dep| {
+        dep["id"].as_i64().unwrap() == engineering_dep_id
+            || dep["id"].as_i64().unwrap() == emerging_technologies_dep_id
+    });
+
+    for dep in departments {
+        for job in dep["jobs"].as_array().unwrap() {
+            let metadata = job["metadata"].as_array().unwrap();
+
+            let locations = metadata
+                .iter()
+                .find(|m| m["name"] == "Job Posting Location")
+                .unwrap()["value"]
+                .as_array()
+                .unwrap();
+
+            for loc in locations {
+                let location = loc.as_str().unwrap();
+                let title = job["title"].as_str().unwrap();
+                let link = job["absolute_url"].as_str().unwrap();
+
+                scraped_jobs.push(ScrapedJob {
+                    title: title.to_string(),
+                    location: location.to_string(),
+                    link: link.to_string(),
+                });
+            }
+        }
+    }
+
+    // Convert Vector of ScrapedJob into a JobsPayload
+    let jobs_payload = JobsPayload::from_scraped_jobs(scraped_jobs, &data.data["Cloudflare"]);
+
+    // REMEBER TO SAVE THE NEW JOBS TO THE DATA STATE
+    data.data.get_mut("Cloudflare").unwrap().jobs = jobs_payload.all_jobs.clone();
+    data.save();
+
+    // Return JobsPayload
+    Ok(jobs_payload)
+}
+

--- a/src/scrapers/mod.rs
+++ b/src/scrapers/mod.rs
@@ -50,3 +50,6 @@ pub mod airbnb {
 pub mod servicenow {
 	pub mod scraper;
 }
+pub mod cloudflare {
+	pub mod scraper;
+}


### PR DESCRIPTION
This pull request adds support for scraping job listings from Cloudflare. The most important changes include importing the necessary modules, updating the list of company keys, adding the scraping functionality, and integrating it into the existing job scraping workflow.

### Additions to support Cloudflare job scraping:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR4): Added the `scrape_cloudflare` function to the imports and included "Cloudflare" in the `COMPANYKEYS` array. Integrated the `scrape_cloudflare` function into the `scrape_jobs` function to handle Cloudflare job listings. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR4) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL68-R74) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR582)

* [`src/scrapers/cloudflare/scraper.rs`](diffhunk://#diff-c240d77e82223a3564ddc87b8d579bc1b439f19cc23c712badf650bbf75c88daR1-R65): Added a new module to define the `scrape_cloudflare` function, which fetches job listings from Cloudflare's Greenhouse API, processes the data, and returns a `JobsPayload`.

* [`src/scrapers/mod.rs`](diffhunk://#diff-1afca3ad4e63fab9249218cc2f68982c09c0e6c0fad68c0e440797f9733a9bf5R53-R55): Added a new submodule for Cloudflare under the `scrapers` module.