### PR TITLE
company: Nike

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use clipboard::{ClipboardContext, ClipboardProvider};
 use colored::*;
+use scrapers::nike::scraper::scrape_nike;
 use core::panic;
 use cron::initialize_cron;
 use dialoguer::theme::ColorfulTheme;
@@ -67,7 +68,7 @@ use webbrowser;
 
 // TODO: Keys should prob be lowercase, make a tuple where 0 is key and 1 is display name, or
 // straight up just an enum
-const COMPANYKEYS: [&str; 27] = [
+const COMPANYKEYS: [&str; 28] = [
     "AirBnB",
     "Anduril",
     "Blizzard",
@@ -88,6 +89,7 @@ const COMPANYKEYS: [&str; 27] = [
     "Gen",
     "Disney",
     "Netflix",
+    "Nike",
     "Meta",
     "Chase",
     "Robinhood",
@@ -598,6 +600,7 @@ pub async fn scrape_jobs(
         "Disney" => scrape_disney(data).await,
         "Meta" => scrape_meta(data).await,
         "Netflix" => scrape_netflix(data).await,
+        "Nike" => scrape_nike(data).await,
         "Square" => scrape_square(data).await,
         "Stripe" => scrape_stripe(data).await,
         "Salesforce" => scrape_salesforce(data).await,

--- a/src/scrapers/mod.rs
+++ b/src/scrapers/mod.rs
@@ -56,3 +56,7 @@ pub mod cloudflare {
 pub mod robinhood {
 	pub mod scraper;
 }
+
+pub mod nike {
+	pub mod scraper;
+}

--- a/src/scrapers/nike/scraper.rs
+++ b/src/scrapers/nike/scraper.rs
@@ -1,0 +1,82 @@
+use std::error::Error;
+
+use serde_json::Value;
+
+use crate::models::{
+    data::Data,
+    scraper::{JobsPayload, ScrapedJob},
+};
+
+pub async fn scrape_nike(data: &mut Data) -> Result<JobsPayload, Box<dyn Error>> {
+    let mut offset = 0;
+    let mut scraped_jobs: Vec<ScrapedJob> = Vec::new();
+    loop {
+        let url = format!("https://jobs.nike.com/cms/api/v1/nike/search/jobs/?offset={}&limit=100&sort_key=posting_start_date&lang=en&categories=Technology&sort_dir=DESC", offset);
+        let mut json: Value = reqwest::get(&url).await?.json().await?;
+
+        let jobs = json["jobs"].as_array_mut().unwrap();
+
+        if jobs.len() == 0 {
+            break;
+        }
+
+        // INFO: Filtering out jobs that are not software engineering roles
+        let valid_job_titles = [
+            "tech lead",
+            "software engineer",
+            "backend developer",
+            "frontend developer",
+            "full stack developer",
+            "software developer",
+            "engineering manager",
+            "engineering director",
+            "engineering lead",
+            "web developer",
+            "mobile developer",
+        ];
+
+        jobs.retain(|job| {
+            let title = job["atsPayload"]["content"]["title"]
+                .as_str()
+                .unwrap()
+                .to_lowercase();
+            valid_job_titles
+                .iter()
+                .any(|valid_title| title.contains(valid_title))
+        });
+        for job in jobs {
+            let title = job["atsPayload"]["content"]["title"]
+                .as_str()
+                .unwrap()
+                .to_string();
+            let link = job["postUrl"].as_str().unwrap().to_string();
+
+            let location = format!(
+                "{}, {}, {}",
+                job["atsPayload"]["location"]["administrational"]["city"]
+                    .as_str()
+                    .unwrap(),
+                job["atsPayload"]["location"]["administrational"]["stateProvince"]
+                    .as_str()
+                    .unwrap(),
+                job["atsPayload"]["location"]["administrational"]["country"]
+                    .as_str()
+                    .unwrap()
+            );
+
+            scraped_jobs.push(ScrapedJob {
+                title,
+                location,
+                link,
+            });
+        }
+        offset += 100;
+    }
+
+    // Convert Vector of ScrapedJob into a JobsPayload
+    let jobs_payload = JobsPayload::from_scraped_jobs(scraped_jobs, "Nike", data);
+
+    // Return JobsPayload
+    Ok(jobs_payload)
+}
+


### PR DESCRIPTION
This pull request introduces a new scraper for Nike job listings and integrates it into the existing job scraping framework. The most important changes include adding the Nike scraper module, updating the job scraping function, and modifying constants to include Nike.

Integration of Nike scraper:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR4): Added `scrape_nike` function to the imports and updated the `COMPANYKEYS` constant to include "Nike". Also, integrated the `scrape_nike` function into the `scrape_jobs` function to handle Nike job listings. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR4) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL70-R71) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR92) [[4]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR603)

New Nike scraper module:

* [`src/scrapers/mod.rs`](diffhunk://#diff-1afca3ad4e63fab9249218cc2f68982c09c0e6c0fad68c0e440797f9733a9bf5R59-R62): Added a new module for Nike under `scrapers`.
* [`src/scrapers/nike/scraper.rs`](diffhunk://#diff-a0e4bb999e350318b9011499e3991acd0d8f496a86ca6e6b85278747e8882453R1-R82): Implemented the `scrape_nike` function to fetch and filter job listings from Nike's job API, retaining only software engineering roles.