### PR TITLE
company: Toast

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 use chrono::Utc;
 use clipboard::{ClipboardContext, ClipboardProvider};
 use colored::*;
-use scrapers::nike::scraper::scrape_nike;
 use core::panic;
 use cron::initialize_cron;
 use dialoguer::theme::ColorfulTheme;
@@ -41,12 +40,14 @@ use scrapers::gen::scraper::scrape_gen;
 use scrapers::ibm::scraper::scrape_ibm;
 use scrapers::meta::scraper::scrape_meta;
 use scrapers::netflix::scraper::scrape_netflix;
+use scrapers::nike::scraper::scrape_nike;
 use scrapers::reddit::scraper::scrape_reddit;
 use scrapers::robinhood::scraper::scrape_robinhood;
 use scrapers::salesforce::scraper::scrape_salesforce;
 use scrapers::servicenow::scraper::scrape_servicenow;
 use scrapers::square::scraper::scrape_square;
 use scrapers::stripe::scraper::scrape_stripe;
+use scrapers::toast::scraper::scrape_toast;
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
@@ -68,7 +69,7 @@ use webbrowser;
 
 // TODO: Keys should prob be lowercase, make a tuple where 0 is key and 1 is display name, or
 // straight up just an enum
-const COMPANYKEYS: [&str; 28] = [
+const COMPANYKEYS: [&str; 29] = [
     "AirBnB",
     "Anduril",
     "Blizzard",
@@ -97,6 +98,7 @@ const COMPANYKEYS: [&str; 28] = [
     "Square",
     "Stripe",
     "Salesforce",
+    "Toast"
 ];
 
 mod cron;
@@ -607,10 +609,10 @@ pub async fn scrape_jobs(
         "ServiceNow" => scrape_servicenow(data).await,
         "GitHub" => default_scrape_jobs_handler(data, GITHUB_SCRAPE_OPTIONS).await,
         "GitLab" => default_scrape_jobs_handler(data, GITLAB_SCRAPE_OPTIONS).await,
+        "Toast" => scrape_toast(data).await,
         "The Browser Company" => {
             default_scrape_jobs_handler(data, THE_BROWSER_COMPANY_DEFAULT_SCRAPE_OPTIONS).await
         }
-        "Toast" => default_scrape_jobs_handler(data, TOAST_DEFAULT_SCRAPE_OPTIONS).await,
 
         _ => return Err(format!("Scraper yet to be implemented for {}", company_key).into()),
     }?;

--- a/src/scrapers/mod.rs
+++ b/src/scrapers/mod.rs
@@ -60,3 +60,7 @@ pub mod robinhood {
 pub mod nike {
 	pub mod scraper;
 }
+
+pub mod toast {
+	pub mod scraper;
+}

--- a/src/scrapers/toast/scraper.rs
+++ b/src/scrapers/toast/scraper.rs
@@ -1,0 +1,75 @@
+use std::error::Error;
+
+use headless_chrome::{Browser, LaunchOptions};
+
+use crate::models::{
+    data::Data,
+    scraper::{JobsPayload, ScrapedJob},
+};
+
+pub async fn scrape_toast(data: &mut Data) -> Result<JobsPayload, Box<dyn Error>> {
+    let launch_options = LaunchOptions {
+        headless: false,
+        window_size: Some((1920, 1080)),
+        enable_logging: true,
+
+        ..LaunchOptions::default()
+    };
+    let browser = Browser::new(launch_options)?;
+
+    let tab = browser.new_tab()?;
+
+    let mut page = 1;
+    let mut scraped_jobs: Vec<ScrapedJob> = Vec::new();
+
+    loop {
+        let url = format!(
+            "https://careers.toasttab.com/jobs/search?page={}&department_uids%5B%5D=546da8e254b79111ee592914ea196336&query=",
+            page
+        );
+        tab.navigate_to(&url)?;
+        tab.wait_for_element("body")?;
+        tab.wait_for_element(".job-search-results-table")?;
+
+        let remote_object = tab.evaluate(
+            r##"
+
+const cards = [...document.querySelectorAll(".job-search-results-card")]
+
+const scrapedJobs = cards.map(card => {
+    const title = card.querySelector(".card-title").innerText.trim();
+    const link  =card.querySelector("a").href;
+
+    const location = (card.querySelector(".job-component-location")?.innerText ?? "Anywhere").trim()
+    
+    return {
+        title,
+        link,
+        location
+        
+    }
+})
+
+JSON.stringify(scrapedJobs)
+    "##,
+            false,
+        )?;
+
+        let scraped_jobs_batch: Vec<ScrapedJob> =
+            serde_json::from_str(remote_object.value.unwrap().as_str().unwrap()).unwrap();
+
+        if scraped_jobs_batch.is_empty() {
+            break;
+        }
+
+        scraped_jobs.extend(scraped_jobs_batch);
+
+        page += 1;
+    }
+
+    // Convert Vector of ScrapedJob into a JobsPayload
+    let jobs_payload = JobsPayload::from_scraped_jobs(scraped_jobs, "Toast", data);
+
+    // Return JobsPayload
+    Ok(jobs_payload)
+}


### PR DESCRIPTION
This pull request introduces the integration of a new scraper for Toast into the existing codebase. The changes include adding the necessary imports, updating constants, and implementing the scraper function for Toast.

### Integration of Toast Scraper:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR43-R50): Added `scrape_toast` to the list of imports and updated the `COMPANYKEYS` array to include "Toast". Modified the `scrape_jobs` function to handle the Toast scraper specifically. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR43-R50) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL71-R72) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR101) [[4]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR612-L613)

### Implementation of Toast Scraper:

* [`src/scrapers/mod.rs`](diffhunk://#diff-1afca3ad4e63fab9249218cc2f68982c09c0e6c0fad68c0e440797f9733a9bf5R63-R66): Added a new module for Toast under `scrapers`.
* [`src/scrapers/toast/scraper.rs`](diffhunk://#diff-16bdecd670689fd59e736df4891bf80ff03a80fe6365cc272d081de0cd735cf9R1-R75): Implemented the `scrape_toast` function, which uses headless Chrome to scrape job listings from Toast's careers page.