### PR TITLE
company: PayPal

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use chrono::Utc;
 use clipboard::{ClipboardContext, ClipboardProvider};
 use colored::*;
 use scrapers::doordash::scraper::scrape_doordash;
+use scrapers::paypal::scraper::scrape_paypal;
 use core::panic;
 use cron::initialize_cron;
 use dialoguer::theme::ColorfulTheme;
@@ -71,7 +72,7 @@ use webbrowser;
 
 // TODO: Keys should prob be lowercase, make a tuple where 0 is key and 1 is display name, or
 // straight up just an enum
-const COMPANYKEYS: [&str; 31] = [
+const COMPANYKEYS: [&str; 32] = [
     "AirBnB",
     "Anduril",
     "Blizzard",
@@ -95,6 +96,7 @@ const COMPANYKEYS: [&str; 31] = [
     "Netflix",
     "Nike",
     "Meta",
+    "PayPal",
     "Chase",
     "Robinhood",
     "ServiceNow",
@@ -600,6 +602,7 @@ pub async fn scrape_jobs(
         "Experian" => scrape_experian(data).await,
         "Discord" => default_scrape_jobs_handler(data, DISCORD_SCRAPE_OPTIONS).await,
         "Palantir" => default_scrape_jobs_handler(data, PALANTIR_DEFAULT_SCRAPE_OPTIONS).await,
+        "PayPal" => scrape_paypal(data).await,
         "Reddit" => scrape_reddit(data).await,
         "Robinhood" => scrape_robinhood(data).await,
         "Gen" => scrape_gen(data).await,

--- a/src/scrapers/mod.rs
+++ b/src/scrapers/mod.rs
@@ -72,3 +72,7 @@ pub mod uber {
 pub mod doordash {
 	pub mod scraper;
 }
+
+pub mod paypal {
+	pub mod scraper;
+}

--- a/src/scrapers/paypal/scraper.rs
+++ b/src/scrapers/paypal/scraper.rs
@@ -1,0 +1,46 @@
+use std::error::Error;
+
+use serde_json::Value;
+
+use crate::models::{
+    data::Data,
+    scraper::{JobsPayload, ScrapedJob},
+};
+
+pub async fn scrape_paypal(data: &mut Data) -> Result<JobsPayload, Box<dyn Error>> {
+    let mut start = 0;
+    let mut scraped_jobs: Vec<ScrapedJob> = Vec::new();
+    loop {
+        let json: Value = reqwest::get(&format!("https://paypal.eightfold.ai/api/apply/v2/jobs?domain=paypal.com&start={}&num=10&exclude_pid=274904231921&pid=274904231921&Job%20Category=Software%20Development&Job%20Category=Machine%20Learning&Job%20Category=Data%20Science&domain=paypal.com&sort_by=relevance", start)).await?.json().await?;
+
+        let positions = json["positions"].as_array().unwrap();
+
+        if positions.is_empty() {
+            break;
+        }
+
+        for position in positions {
+            for location in position["locations"].as_array().unwrap() {
+                let title = position["name"].as_str().unwrap().to_string();
+                let link = position["canonicalPositionUrl"]
+                    .as_str()
+                    .unwrap()
+                    .to_string();
+
+                scraped_jobs.push(ScrapedJob {
+                    title,
+                    link,
+                    location: location.as_str().unwrap().to_string(),
+                });
+            }
+        }
+
+        start += 10;
+    }
+
+    // Convert Vector of ScrapedJob into a JobsPayload
+    let jobs_payload = JobsPayload::from_scraped_jobs(scraped_jobs, "PayPal", data);
+    // Return JobsPayload
+    Ok(jobs_payload)
+}
+


### PR DESCRIPTION
This pull request introduces support for scraping job listings from PayPal. The most important changes include adding a new scraper module for PayPal, updating the list of company keys, and integrating the new scraper into the existing job scraping functionality.

New scraper integration:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR5): Added the new PayPal scraper to the list of imports and integrated it into the `scrape_jobs` function. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR5) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR605)

Updates to company keys:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL74-R75): Updated the `COMPANYKEYS` array to include "PayPal". [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL74-R75) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR99)

New scraper module:

* [`src/scrapers/mod.rs`](diffhunk://#diff-1afca3ad4e63fab9249218cc2f68982c09c0e6c0fad68c0e440797f9733a9bf5R75-R78): Added a new module for the PayPal scraper.
* [`src/scrapers/paypal/scraper.rs`](diffhunk://#diff-4a8b15766d07e21288262fa92d2582aed1db3d8950b9f22c4b30d68bd29a4f16R1-R46): Implemented the PayPal scraper function to fetch and parse job listings from PayPal's API.