### PR TITLE
company: Atlassian

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,6 @@
 use chrono::Utc;
 use clipboard::{ClipboardContext, ClipboardProvider};
 use colored::*;
-use scrapers::doordash::scraper::scrape_doordash;
-use scrapers::paypal::scraper::scrape_paypal;
 use core::panic;
 use cron::initialize_cron;
 use dialoguer::theme::ColorfulTheme;
@@ -30,6 +28,7 @@ use models::gemini::GeminiJob;
 use models::scraper::{Job, JobsPayload};
 use reqwest::Client;
 use scrapers::airbnb::scraper::scrape_airbnb;
+use scrapers::atlassian::scraper::scrape_atlassian;
 use scrapers::blizzard::scraper::scrape_blizzard;
 use scrapers::chase::scraper::scrape_chase;
 use scrapers::cisco::scraper::scrape_cisco;
@@ -37,12 +36,14 @@ use scrapers::cloudflare::scraper::scrape_cloudflare;
 use scrapers::coinbase::scraper::scrape_coinbase;
 use scrapers::costar_group::scraper::scrape_costar_group;
 use scrapers::disney::scraper::scrape_disney;
+use scrapers::doordash::scraper::scrape_doordash;
 use scrapers::experian::scraper::scrape_experian;
 use scrapers::gen::scraper::scrape_gen;
 use scrapers::ibm::scraper::scrape_ibm;
 use scrapers::meta::scraper::scrape_meta;
 use scrapers::netflix::scraper::scrape_netflix;
 use scrapers::nike::scraper::scrape_nike;
+use scrapers::paypal::scraper::scrape_paypal;
 use scrapers::reddit::scraper::scrape_reddit;
 use scrapers::robinhood::scraper::scrape_robinhood;
 use scrapers::salesforce::scraper::scrape_salesforce;
@@ -72,9 +73,10 @@ use webbrowser;
 
 // TODO: Keys should prob be lowercase, make a tuple where 0 is key and 1 is display name, or
 // straight up just an enum
-const COMPANYKEYS: [&str; 32] = [
+const COMPANYKEYS: [&str; 33] = [
     "AirBnB",
     "Anduril",
+    "Atlassian",
     "Blizzard",
     "Cisco",
     "Cloudflare",
@@ -590,6 +592,7 @@ pub async fn scrape_jobs(
     let jobs_payload = match company_key {
         "AirBnB" => scrape_airbnb(data).await,
         "Anduril" => default_scrape_jobs_handler(data, ANDURIL_SCRAPE_OPTIONS).await,
+        "Atlassian" => scrape_atlassian(data).await,
         "Chase" => scrape_chase(data).await,
         "Cloudflare" => scrape_cloudflare(data).await,
         "Cisco" => scrape_cisco(data).await,

--- a/src/scrapers/atlassian/scraper.rs
+++ b/src/scrapers/atlassian/scraper.rs
@@ -1,0 +1,65 @@
+use std::error::Error;
+
+use reqwest::Client;
+use serde_json::Value;
+
+use crate::models::{
+    data::Data,
+    scraper::{JobsPayload, ScrapedJob},
+};
+
+pub async fn scrape_atlassian(data: &mut Data) -> Result<JobsPayload, Box<dyn Error>> {
+    let client = Client::new();
+    let json: Value = client
+    .get("https://www.atlassian.com/endpoint/careers/listings")
+    .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+    .send()
+    .await?
+    .json()
+    .await?;
+
+    let jobs_of_interest = json.as_array().unwrap().iter().filter(|&j| {
+        let category = j["category"].as_str().unwrap();
+        if category == "Engineering" || category == "Interns" || category == "Graduates" {
+            return true;
+        } else {
+            return false;
+        }
+    });
+
+    let mut scraped_jobs: Vec<ScrapedJob> = Vec::new();
+
+    for job in jobs_of_interest {
+        let locations = job["locations"].as_array().unwrap();
+
+        for location in locations {
+            let title = job["title"].as_str().unwrap().trim().to_string();
+            let formatted_location = location
+                .as_str()
+                .unwrap()
+                .split("-")
+                .take(2)
+                .map(|s| s.trim())
+                .collect::<Vec<&str>>()
+                .join(", ");
+
+            let link = job["portalJobPost"]["portalUrl"]
+                .as_str()
+                .unwrap()
+                .to_string();
+
+            let scraped_job = ScrapedJob {
+                title,
+                location: formatted_location,
+                link,
+            };
+
+            scraped_jobs.push(scraped_job);
+        }
+    }
+
+    let jobs_payload = JobsPayload::from_scraped_jobs(scraped_jobs, "Atlassian", data);
+
+    // Return JobsPayload
+    Ok(jobs_payload)
+}

--- a/src/scrapers/mod.rs
+++ b/src/scrapers/mod.rs
@@ -76,3 +76,7 @@ pub mod doordash {
 pub mod paypal {
 	pub mod scraper;
 }
+
+pub mod atlassian {
+	pub mod scraper;
+}


### PR DESCRIPTION
This pull request adds support for scraping job listings from Atlassian in the `src/main.rs` file and its related modules. The most important changes include adding the `scrape_atlassian` function, updating the list of company keys, and modifying the `scrape_jobs` function to handle Atlassian.

New scraper function:

* [`src/scrapers/atlassian/scraper.rs`](diffhunk://#diff-d76c4fb60cd48ae368d4b3bfee2bb67b27235b7b15d3e2002dfddcc24ce748f9R1-R65): Added a new scraper function `scrape_atlassian` to fetch job listings from Atlassian's careers endpoint.

Updates to main file:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR31-R46): Added `scrape_atlassian` to the list of scraper imports.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL75-R79): Updated the `COMPANYKEYS` array to include "Atlassian".
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR595): Modified the `scrape_jobs` function to handle Atlassian job listings by calling `scrape_atlassian`.

Module update:

* [`src/scrapers/mod.rs`](diffhunk://#diff-1afca3ad4e63fab9249218cc2f68982c09c0e6c0fad68c0e440797f9733a9bf5R79-R82): Added a new module for Atlassian's scraper.