### PR TITLE
Data struct refactor and preparation for `smart_criteria`

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -87,10 +87,10 @@ pub async fn initialize_discord_mode(
 
 async fn scan_for_new_jobs(scan_all_companies: bool) -> Vec<FormattedJob> {
     let mut data = Data::get_data();
-    let mut company_keys: Vec<String> = data.data.keys().cloned().collect();
+    let mut company_keys: Vec<String> = data.companies.keys().cloned().collect();
 
     if !scan_all_companies {
-        company_keys.retain(|k| data.data[k].is_following || !data.data[k].connections.is_empty());
+        company_keys.retain(|k| data.companies[k].is_following || !data.companies[k].connections.is_empty());
     }
 
     let mut total_new_jobs: Vec<FormattedJob> = Vec::new();

--- a/src/handlers/handlers.rs
+++ b/src/handlers/handlers.rs
@@ -419,7 +419,7 @@ pub async fn handle_scan_new_jobs_across_network_and_followed_companies(
 ) -> Result<Vec<FormattedJob>, Box<dyn Error>> {
     clear_console();
     let companies_to_scrape: Vec<String> = data
-        .data
+        .companies
         .iter()
         // Filter out companies where connections.len() > 0 or company.is_following equals true
         .filter(|(_, c)| {
@@ -578,7 +578,7 @@ pub async fn handle_manage_connection(
 
                 if confirm {
                     // Filter out the connection from all companies
-                    if let Some(company) = data.data.get_mut(company_name) {
+                    if let Some(company) = data.companies.get_mut(company_name) {
                         company.connections.retain(|c| {
                             c.first_name != connection.first_name
                                 || c.last_name != connection.last_name

--- a/src/models/scraper.rs
+++ b/src/models/scraper.rs
@@ -158,7 +158,7 @@ impl JobsPayload {
         let mut all_jobs: Vec<Job> = Vec::new();
         let mut new_jobs: Vec<Job> = Vec::new();
 
-        let company = data.data.get_mut(company_key).unwrap();
+        let company = data.companies.get_mut(company_key).unwrap();
         // Check for first scrape
         if company.jobs.is_empty() {
             all_jobs = scraped_jobs


### PR DESCRIPTION
This pull request mainly focuses on renaming the `data` field to `companies` in several files to improve code clarity and consistency. Additionally, it introduces a new field `smart_criteria` to the `Data` struct.

Key changes include:

### Field Renaming:

* [`src/discord.rs`](diffhunk://#diff-13c018b973379678dc59768c60f730ce55d8a95e301588f73f41b7f1ccdc328bL90-R93): Renamed `data` to `companies` in `scan_for_new_jobs` function.
* [`src/handlers/handlers.rs`](diffhunk://#diff-71c8b68f6fdc6419a2e4fc4695c03793ac5bb8be025ed84f5669655940a65eb4L422-R422): Renamed `data` to `companies` in multiple functions, including `handle_scan_new_jobs_across_network_and_followed_companies` and `handle_manage_connection`. [[1]](diffhunk://#diff-71c8b68f6fdc6419a2e4fc4695c03793ac5bb8be025ed84f5669655940a65eb4L422-R422) [[2]](diffhunk://#diff-71c8b68f6fdc6419a2e4fc4695c03793ac5bb8be025ed84f5669655940a65eb4L581-R581)
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL250-R251): Renamed `data` to `companies` in multiple locations within the `main` function and other related functions. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL250-R251) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL335-R351) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL374-R375) [[4]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL488-R489) [[5]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL555-R556) [[6]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL653-R654) [[7]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL662-R666)
* [`src/models/data.rs`](diffhunk://#diff-2d28a91b5fb890962f8483136e4c3b7b470f891163d85c49b61ca29992cda3a1L114-R122): Renamed `data` to `companies` in the `Data` struct and related methods. [[1]](diffhunk://#diff-2d28a91b5fb890962f8483136e4c3b7b470f891163d85c49b61ca29992cda3a1L114-R122) [[2]](diffhunk://#diff-2d28a91b5fb890962f8483136e4c3b7b470f891163d85c49b61ca29992cda3a1L172-R174) [[3]](diffhunk://#diff-2d28a91b5fb890962f8483136e4c3b7b470f891163d85c49b61ca29992cda3a1L231-R242) [[4]](diffhunk://#diff-2d28a91b5fb890962f8483136e4c3b7b470f891163d85c49b61ca29992cda3a1L312-R318) [[5]](diffhunk://#diff-2d28a91b5fb890962f8483136e4c3b7b470f891163d85c49b61ca29992cda3a1L330-R336) [[6]](diffhunk://#diff-2d28a91b5fb890962f8483136e4c3b7b470f891163d85c49b61ca29992cda3a1L347-R353) [[7]](diffhunk://#diff-2d28a91b5fb890962f8483136e4c3b7b470f891163d85c49b61ca29992cda3a1L356-R362)
* [`src/models/scraper.rs`](diffhunk://#diff-17e6e4233e5044337d53876da1bd81d38f30139bc0fcdb74cc8aa1e8009a0757L161-R161): Renamed `data` to `companies` in the `JobsPayload` implementation.

### New Field Addition:

* [`src/models/data.rs`](diffhunk://#diff-2d28a91b5fb890962f8483136e4c3b7b470f891163d85c49b61ca29992cda3a1L114-R122): Added `smart_criteria` and `smart_criteria_enabled` fields to the `Data` struct. [[1]](diffhunk://#diff-2d28a91b5fb890962f8483136e4c3b7b470f891163d85c49b61ca29992cda3a1L114-R122) [[2]](diffhunk://#diff-2d28a91b5fb890962f8483136e4c3b7b470f891163d85c49b61ca29992cda3a1L231-R242)