### PR TITLE
New Company: Panasonic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ use scrapers::ibm::scraper::scrape_ibm;
 use scrapers::meta::scraper::scrape_meta;
 use scrapers::netflix::scraper::scrape_netflix;
 use scrapers::nike::scraper::scrape_nike;
+use scrapers::panasonic::scraper::scrape_panasonic;
 use scrapers::paypal::scraper::scrape_paypal;
 use scrapers::reddit::scraper::scrape_reddit;
 use scrapers::robinhood::scraper::scrape_robinhood;
@@ -58,7 +59,7 @@ use webbrowser;
 
 // TODO: Keys should prob be lowercase, make a tuple where 0 is key and 1 is display name, or
 // straight up just an enum
-const COMPANYKEYS: [&str; 33] = [
+const COMPANYKEYS: [&str; 34] = [
     "AirBnB",
     "Anduril",
     "Atlassian",
@@ -84,6 +85,7 @@ const COMPANYKEYS: [&str; 33] = [
     "Nike",
     "Meta",
     "PayPal",
+    "Panasonic",
     "Chase",
     "Robinhood",
     "ServiceNow",
@@ -580,6 +582,7 @@ pub async fn scrape_jobs(data: &mut Data, company_key: &str) -> AppResult<JobsPa
         "Experian" => scrape_experian(data).await,
         "Discord" => default_scrape_jobs_handler(data, DISCORD_SCRAPE_OPTIONS).await,
         "Palantir" => default_scrape_jobs_handler(data, PALANTIR_DEFAULT_SCRAPE_OPTIONS).await,
+        "Panasonic" => scrape_panasonic(data).await,
         "PayPal" => scrape_paypal(data).await,
         "Reddit" => scrape_reddit(data).await,
         "Robinhood" => scrape_robinhood(data).await,

--- a/src/scrapers/mod.rs
+++ b/src/scrapers/mod.rs
@@ -80,3 +80,7 @@ pub mod paypal {
 pub mod atlassian {
 	pub mod scraper;
 }
+
+pub mod panasonic {
+	pub mod scraper;
+}

--- a/src/scrapers/panasonic/scraper.rs
+++ b/src/scrapers/panasonic/scraper.rs
@@ -1,0 +1,54 @@
+use std::error::Error;
+
+use serde_json::Value;
+
+use crate::{
+    error::AppResult,
+    models::{
+        data::Data,
+        scraper::{JobsPayload, ScrapedJob},
+    },
+};
+
+pub async fn scrape_panasonic(data: &mut Data) -> AppResult<JobsPayload> {
+    let mut page = 1;
+
+    let mut scraped_jobs = Vec::new();
+    loop {
+        let api_url =
+            format!("https://careers.na.panasonic.com/api/jobs?page={page}&categories=Engineering");
+
+        let json: Value = reqwest::get(&api_url).await?.json().await?;
+
+        let jobs: Vec<Value> = json["jobs"].as_array().cloned().unwrap();
+
+        if jobs.is_empty() {
+            break;
+        }
+
+        let scarped_jobs_batch: Vec<ScrapedJob> = jobs
+            .iter()
+            .map(|j| ScrapedJob {
+                title: j["data"]["title"].as_str().unwrap().to_string(),
+                location: format!(
+                    "{}, {}",
+                    j["data"]["city"].as_str().unwrap(),
+                    j["data"]["country"].as_str().unwrap()
+                ),
+                link: j["data"]["meta_data"]["canonical_url"]
+                    .as_str()
+                    .unwrap()
+                    .to_string(),
+            })
+            .collect();
+
+        scraped_jobs.extend(scarped_jobs_batch);
+
+        page += 1;
+    }
+
+    let jobs_payload = JobsPayload::from_scraped_jobs(scraped_jobs, "Panasonic", data);
+    // Return JobsPayload
+    Ok(jobs_payload)
+}
+


### PR DESCRIPTION
This pull request introduces a new scraper for Panasonic job listings and integrates it into the existing system. The most important changes include adding the Panasonic scraper, updating the list of company keys, and modifying the job scraping function to include Panasonic.

New scraper integration:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR41): Added the `scrape_panasonic` function to the list of imported scrapers and included "Panasonic" in the `COMPANYKEYS` array. Also updated the `scrape_jobs` function to handle the "Panasonic" company key. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR41) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL61-R62) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR88) [[4]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR585)
* [`src/scrapers/mod.rs`](diffhunk://#diff-1afca3ad4e63fab9249218cc2f68982c09c0e6c0fad68c0e440797f9733a9bf5R83-R86): Added a new module for Panasonic under `scrapers`.
* [`src/scrapers/panasonic/scraper.rs`](diffhunk://#diff-a69d773761c1c76f2c05d9bfa22e5349f8b3becb7a59dbf7764f5d4c29cbea9aR1-R54): Implemented the `scrape_panasonic` function to fetch and parse job listings from Panasonic's careers API.