### PR TITLE
Fix: `Select a Company` returns corrcet company

### DIFF
--- a/src/company_options.rs
+++ b/src/company_options.rs
@@ -26,7 +26,7 @@ use crate::{
     },
 };
 
-#[derive(EnumIter, Debug, Display)]
+#[derive(EnumIter, Debug, Display, Clone)]
 pub enum CompanyOption {
     #[strum(to_string = "AirBnB")]
     AirBnb,

--- a/src/handlers/handlers.rs
+++ b/src/handlers/handlers.rs
@@ -58,23 +58,30 @@ impl<T: IntoEnumIterator + Display> EnumVariantsDisplayStrings for T {}
 pub fn prompt_user_for_company_selection_v2() -> Option<CompanyOption> {
     let dialoguer_styles = ColorfulTheme::default();
 
-    // create company options with back option
+    // Create a sorted list of CompanyOption instances
+    let mut company_options: Vec<CompanyOption> = CompanyOption::iter().collect();
+    company_options.sort_by_key(|opt| opt.to_string());
 
-    let mut company_options = CompanyOption::display_strings();
-    company_options.sort();
-    company_options.push("Back".to_string());
+    // Add "Back" option
+    let mut display_options = company_options
+        .iter()
+        .map(|opt| opt.to_string())
+        .collect::<Vec<String>>();
+
+    display_options.push("Back".to_string());
 
     let selection = FuzzySelect::with_theme(&dialoguer_styles)
         .with_prompt("Select a company")
-        .items(&company_options)
+        .items(&display_options)
         .interact()
         .unwrap();
 
-    if selection == company_options.len() - 1 {
+    if selection == display_options.len() - 1 {
         return None;
     }
 
-    return Some(CompanyOption::iter().nth(selection).unwrap());
+    // Return the selected company from the sorted list
+    Some(company_options[selection].clone())
 }
 // INFO: Company Options Prompt
 #[derive(Display, EnumIter)]


### PR DESCRIPTION
This pull request includes changes to the `src/company_options.rs` and `src/handlers/handlers.rs` files to improve the handling of `CompanyOption` instances and the user prompt for company selection. The most important changes include adding the `Clone` trait to the `CompanyOption` enum and refactoring the company selection prompt to sort options and handle selections more effectively.

Enhancements to `CompanyOption` enum:

* [`src/company_options.rs`](diffhunk://#diff-95b1bb35ab23f2aed7a41fdd6a7ba299f2ac0ddab068eddef30e115b6df61e5aL29-R29): Added the `Clone` trait to the `CompanyOption` enum to allow instances of `CompanyOption` to be cloned.

Improvements to company selection prompt:

* [`src/handlers/handlers.rs`](diffhunk://#diff-71c8b68f6fdc6419a2e4fc4695c03793ac5bb8be025ed84f5669655940a65eb4L61-R84): Refactored the `prompt_user_for_company_selection_v2` function to create a sorted list of `CompanyOption` instances and handle the "Back" option more effectively. This includes sorting the options, converting them to display strings, and ensuring the correct company is returned based on the user's selection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced company selection functionality with improved sorting and direct enum handling
	- Updated function to return the selected `CompanyOption` instead of a string representation

- **Refactor**
	- Improved company selection process by working directly with `CompanyOption` enum
	- Added `Clone` trait to `CompanyOption` enum for better usability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->